### PR TITLE
Fix crash on iOS 10.

### DIFF
--- a/DocumentDetectionDemo/ScanbotSDKTestApp/Info.plist
+++ b/DocumentDetectionDemo/ScanbotSDKTestApp/Info.plist
@@ -49,5 +49,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Please allow access to camera</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Please allow access to photo library</string>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -171,3 +171,7 @@ of the cropped image and let it be very close to the original documents aspect r
 - The photo filter is useful to correct strong color tints, the 2 other new filters create different color-to-gray mappings 
 - Added SBSDKMultipleDocumentsDetector (Beta) to detect multiple photos or documents on an image
 - Minor fixes and optimizations
+
+##### Changelog version 1.2.1:
+
+- Fixed crash in sample app by adding `NSCameraUsageDescription` and `NSPhotoLibraryUsageDescription`.


### PR DESCRIPTION
iOS 10 now require to have NSCameraUsageDescription and NSPhotoLibraryUsageDescription in info.plist file.